### PR TITLE
More changes to translations links

### DIFF
--- a/docs/www/docs.html
+++ b/docs/www/docs.html
@@ -58,26 +58,27 @@
     <h3>Translations</h3>
     <ul class="list-unstyled">
         <li>
-            <a href="http://perldoc.jp">perldoc.jp</a>
-        </li>
-        <li>
-            <a href="http://www.perl.it/documenti/index.html">Italian</a> (Also <a href="http://pod2it.sourceforge.net/">pod2it</a>)
-        </li>
-        <li>
-            <a href="http://perl.enstimac.fr/DocFr.html">French</a>
-        </li>
-        <li>
-            <a href="https://metacpan.org/release/POD2-PT_BR">Brazilian portuguese</a>
-        </li>
-        <li>
-            <a href="https://metacpan.org/release/POD2-LT">Lithuanian</a>
+            <a href="http://perldoc.jp/">Japanese</a>
         </li>
         <li>
             <a href="https://metacpan.org/release/POD2-ES">Spanish</a>
         </li>
         <li>
             <a href="https://metacpan.org/release/POD2-RU">Russian</a>
-</li>    </ul>
+        </li>
+        <li>
+            <a href="https://metacpan.org/release/POD2-PT_BR">Brazilian portuguese</a>
+        </li>
+        <li>
+            <a href="http://www.perl.it//documenti/pod2it/">Italian</a>
+        </li>
+        <li>
+            <a href="http://perl.enstimac.fr/DocFr.html">French</a>
+        </li>
+        <li>
+            <a href="https://metacpan.org/release/POD2-LT">Lithuanian</a>
+        </li>
+    </ul>
   </div>
 </div>
 


### PR DESCRIPTION
Unified titles (Japanese).
Remove Italian Source Forge project link because is referred into first Italian link (and corrected).
Ordered by last update time.